### PR TITLE
Optimizations

### DIFF
--- a/frmAction.cs
+++ b/frmAction.cs
@@ -759,7 +759,7 @@ namespace DupeClear
                 lblStatus5.Text = status5;
 
             if (progressBar1.Value != progress)
-            progressBar1.Value = progress;
+                progressBar1.Value = progress;
 
             string title = "";
             if (TypeOfWork == 0)

--- a/frmAction.cs
+++ b/frmAction.cs
@@ -263,26 +263,16 @@ namespace DupeClear
                     //compare size                    
                     if (mainFileList[j].size != mainFileList[i].size) continue;
 
-                    //compare hash/contents
-                    if (mainFileList[i].hash == "")
-                    {
-                        mainFileList[i].hash = general.hashFile(mainFileList[i].path);
-                    }
-                    if (mainFileList[j].hash == "")
-                    {
-                        mainFileList[j].hash = general.hashFile(mainFileList[j].path);
-                    }
-                    if (soSameContents && (mainFileList[j].hash != mainFileList[i].hash))
-                        continue;
-
                     //match same name
                     if (soSameFileName)
                         if (general.GetFileName(mainFileList[j].path, false).ToLower() != general.GetFileName(mainFileList[i].path, false).ToLower())
                             continue;
+
                     //match same type
                     if (soSameType)
                         if (general.GetFileExt(mainFileList[j].path) != general.GetFileExt(mainFileList[i].path))
                             continue;
+
                     //match same folder
                     if (soSameFolder)
                         if (general.GetFolderPath(mainFileList[j].path).ToLower() != general.GetFolderPath(mainFileList[i].path).ToLower())
@@ -294,10 +284,27 @@ namespace DupeClear
                     if (soSameCreationTime)
                         if (fj.CreationTime != new FileInfo(mainFileList[i].path).CreationTime)
                             continue;
+                    
                     //match same modification date
                     if (soSameModificationTime)
                         if (fj.LastWriteTime != new FileInfo(mainFileList[i].path).LastWriteTime)
                             continue;
+
+                    if (soSameContents)
+                    {
+                        //compare hash/contents
+                        if (mainFileList[i].hash == "")
+                        {
+                            mainFileList[i].hash = general.hashFile(mainFileList[i].path);
+                        }
+                        if (mainFileList[j].hash == "")
+                        {
+                            mainFileList[j].hash = general.hashFile(mainFileList[j].path);
+                        }
+
+                        if (mainFileList[j].hash != mainFileList[i].hash)
+                            continue;
+                    }
 
                     //DUPE FOUND AT THIS STAGE ################################################################
                     ListViewItem item = new ListViewItem();
@@ -751,6 +758,7 @@ namespace DupeClear
             if (status5 != "")
                 lblStatus5.Text = status5;
 
+            if (progressBar1.Value != progress)
             progressBar1.Value = progress;
 
             string title = "";


### PR DESCRIPTION
Not sure if you accept pull requests, but I have made a few optimizations.

1. Re-Ordered some lines so that the fast comparisons (e.g. checking dates, file type or folder names) are performed before computing the hashes (which is time-consuming, especially on large files).
 
2. If we are not comparing file contents, there is no need to compute the hash on files.
 
3. Only update the progress bar if the percentage has changed.
 

These changes will probably not make much difference if you are using the default search options, but one of my searches went from approximately 45 minutes to approximately 30 minutes.